### PR TITLE
Added intra broker disk balance support and more details on executor tasks

### DIFF
--- a/src/components/AdminBroker.vue
+++ b/src/components/AdminBroker.vue
@@ -751,6 +751,7 @@ export default {
         // ?dryrun=[true/false]
         // ?rebalance_disk=true
         params.rebalance_disk = 'true'
+
         return vm.$helpers.getURL('rebalance', params)
       }
       // console.log(' no url !')

--- a/src/components/AdminBroker.vue
+++ b/src/components/AdminBroker.vue
@@ -72,6 +72,10 @@
           <label class="form-check-label">Rebalance Cluster</label>
         </div>
         <div class="form-check form-check-inline">
+          <input class="form-check-input" type="radio" value="rebalance_disk" v-model='actionName' :disabled='selectedBrokers.length != 0'>
+          <label class="form-check-label">Rebalance Broker Disks</label>
+        </div>
+        <div class="form-check form-check-inline">
           <input class="form-check-input" type="radio" value="add" v-model='actionName' :disabled='selectedBrokers.length == 0'>
           <label class="form-check-label">Add Brokers</label>
         </div>
@@ -119,6 +123,24 @@
           <button @click='actionBroker' class="btn btn-primary">Run PLE</button>
         </div>
       </div>
+
+      <!-- Rebalance Broker Disk -->
+      <div class="alert alert-primary" v-if='actionName === "rebalance_disk"'>
+        <h5>Rebalance Broker Disks</h5>
+        <hr>
+        <div class="row">
+          <div class="col-md-4">
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="checkbox" v-model='dryrun'>
+              <label class="form-check-label">DryRun</label>
+            </div>
+          </div>
+        </div>
+        <div class="text-right">
+          <button @click='actionBroker' class="btn btn-primary">Run Broker Disk Rebalance</button>
+        </div>
+      </div>
+
 
       <!-- Rebalance Cluster Flags -->
       <div class="alert alert-info" v-if='actionName === "rebalance"'>
@@ -722,6 +744,13 @@ export default {
         //  &concurrent_partition_movements_per_broker=[concurrency]
         //  &concurrent_leader_movements=[concurrency]
         //  &excluded_topics=[TOPICS]
+        return vm.$helpers.getURL('rebalance', params)
+      }
+      if (vm.actionName === 'rebalance_disk') {
+        // POST /kafkacruisecontrol/rebalance
+        // ?dryrun=[true/false]
+        // ?rebalance_disk=true
+        params.rebalance_disk='true'
         return vm.$helpers.getURL('rebalance', params)
       }
       // console.log(' no url !')

--- a/src/components/AdminBroker.vue
+++ b/src/components/AdminBroker.vue
@@ -750,7 +750,7 @@ export default {
         // POST /kafkacruisecontrol/rebalance
         // ?dryrun=[true/false]
         // ?rebalance_disk=true
-        params.rebalance_disk='true'
+        params.rebalance_disk = 'true'
         return vm.$helpers.getURL('rebalance', params)
       }
       // console.log(' no url !')

--- a/src/components/Executor.vue
+++ b/src/components/Executor.vue
@@ -29,7 +29,7 @@
           </div>
         </div>
       </div>
-      <div v-if='(/\\*._TASK_IN_PROGRESS/.test(ExecutorState.state) || ExecutorState.state === "STOPPING_EXECUTION")' class="card">
+      <div v-if='(/\\*._MOVEMENT_TASK_IN_PROGRESS/.test(ExecutorState.state) || ExecutorState.state === "STOPPING_EXECUTION")' class="card">
         <div class='card-header'>
           {{ ExecutorState.state | camelCase }}
         </div>

--- a/src/components/Executor.vue
+++ b/src/components/Executor.vue
@@ -109,19 +109,19 @@
             <div class="card">
               <div class="card-header">Aborting Partitions</div>
               <div class="card-body">
-                <p class="card-text"><h1 class="text-primary">{{ ExecutorState.abortingPartitions.length }}</h1></p>
+                <p class="card-text"><h1 class="text-primary">{{ ExecutorState.abortingPartitions }}</h1></p>
               </div>
             </div>
             <div class="card">
               <div class="card-header">Aborted Partitions</div>
               <div class="card-body">
-                <p class="card-text"><h1 class="text-success">{{ ExecutorState.abortedPartitions.length }}</h1></p>
+                <p class="card-text"><h1 class="text-success">{{ ExecutorState.abortedPartitions }}</h1></p>
               </div>
             </div>
             <div class="card">
               <div class="card-header">Dead Partitions</div>
               <div class="card-body">
-                <p class="card-text"><h1 class="text-info">{{ ExecutorState.deadPartitions.length }}</h1></p>
+                <p class="card-text"><h1 class="text-info">{{ ExecutorState.deadPartitions }}</h1></p>
               </div>
             </div>
           </div>

--- a/src/components/Executor.vue
+++ b/src/components/Executor.vue
@@ -201,7 +201,7 @@ export default {
     getState () {
       const vm = this
       vm.loading = true
-      vm.$http.get(vm.url, {withCredentials: true, headers: {Cache-Control: 'no-cache'}}).then((r) => {
+      vm.$http.get(vm.url, {withCredentials: true, headers: {'Cache-Control': 'no-cache'}}).then((r) => {
         if (r.data === null || r.data === undefined || r.data === '') {
           vm.error = true
           vm.errorData = 'CruiseControl sent an empty response with 200-OK status code. Please file a bug here https://github.com/linkedin/cruise-control/issues'

--- a/src/components/Executor.vue
+++ b/src/components/Executor.vue
@@ -201,7 +201,7 @@ export default {
     getState () {
       const vm = this
       vm.loading = true
-      vm.$http.get(vm.url, {withCredentials: true}).then((r) => {
+      vm.$http.get(vm.url, {withCredentials: true, headers: {Cache-Control: 'no-cache'}}).then((r) => {
         if (r.data === null || r.data === undefined || r.data === '') {
           vm.error = true
           vm.errorData = 'CruiseControl sent an empty response with 200-OK status code. Please file a bug here https://github.com/linkedin/cruise-control/issues'

--- a/src/components/Executor.vue
+++ b/src/components/Executor.vue
@@ -29,7 +29,7 @@
           </div>
         </div>
       </div>
-      <div v-if='(ExecutorState.state === "REPLICA_MOVEMENT_TASK_IN_PROGRESS" || ExecutorState.state === "STOPPING_EXECUTION")' class="card">
+      <div v-if='(/\\*._TASK_IN_PROGRESS/.test(ExecutorState.state) || ExecutorState.state === "STOPPING_EXECUTION")' class="card">
         <div class='card-header'>
           {{ ExecutorState.state | camelCase }}
         </div>


### PR DESCRIPTION
![Screen Shot 2019-07-03 at 4 37 02 PM](https://user-images.githubusercontent.com/1124115/60623501-cd8ebf00-9db0-11e9-8cc1-edb1e44ebd8e.png)

![Screen Shot 2019-07-19 at 4 00 24 PM](https://user-images.githubusercontent.com/1124115/61562052-73435e80-aa3e-11e9-9f01-7a0bc5faae8e.png)


part of this PR is related to the feature request: https://github.com/linkedin/cruise-control-ui/issues/25
user can then trigger intra broker disk balance easily here. 

also this PR allowed executor tasks to show more details. 