### PR TITLE
Add RackAwareDistributionGoal hard goal

### DIFF
--- a/src/goals.js
+++ b/src/goals.js
@@ -8,6 +8,12 @@ export default {
       'description': 'Ensures that all replicas of each partition are assigned in a rack aware manner -- i.e. no more than one replica of each partition resides in the same rack.'
     },
     {
+      'goal': 'RackAwareDistributionGoal',
+      'hardGoal': true,
+      'group': 1,
+      'description': 'A relaxed version of RackAwareGoal to use in clusters with partitions whose replication factor > number of racks.'
+    },
+    {
       'goal': 'ReplicaCapacityGoal',
       'hardGoal': true,
       'group': 1,


### PR DESCRIPTION
New hard goal [RackAwareDistributionGoal](https://github.com/linkedin/cruise-control/commit/7a6b758bd637d086c95a7826bd54f043e5cdf06b) have been added in Cruise Contol [2.0.131](https://github.com/linkedin/cruise-control/releases/tag/2.0.131)

This goal supersedes `RackAwareGoal` in clusters with partitions whose replication factor > number of racks.