### PR TITLE
add distribution charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/chart.js": {
+      "version": "2.9.28",
+      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.28.tgz",
+      "integrity": "sha512-9YYhsxRngRJb0dkuaU5BezkF+zvvVHnwdRw+rtlahtFb4zqNf9YSgWsOq+dLYeh0fqsWmHUYLR64eNigh02F+w==",
+      "requires": {
+        "moment": "^2.10.2"
+      }
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
@@ -1939,6 +1947,32 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "chart.js": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+      "requires": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
     "check-types": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
@@ -2202,7 +2236,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2210,8 +2243,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
@@ -10069,6 +10101,14 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/vue-axios/-/vue-axios-2.1.5.tgz",
       "integrity": "sha512-th5xVbInVoyIoe+qY+9GCflEVezxAvztD4xpFF39SRQYqpoKD2qkmX8yv08jJG9a2SgNOCjirjJGSwg/wTrbmA=="
+    },
+    "vue-chartjs": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-3.5.1.tgz",
+      "integrity": "sha512-foocQbJ7FtveICxb4EV5QuVpo6d8CmZFmAopBppDIGKY+esJV8IJgwmEW0RexQhxqXaL/E1xNURsgFFYyKzS/g==",
+      "requires": {
+        "@types/chart.js": "^2.7.55"
+      }
     },
     "vue-hot-reload-api": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bootstrap": "^4.4.1",
     "bootswatch": "^4.4.1",
     "build-url": "^1.0.10",
+    "chart.js": "^2.9.4",
     "jquery": "^3.5.0",
     "lodash.sortby": "^4.7.0",
     "moment": "^2.18.1",
@@ -23,6 +24,7 @@
     "url-parse": "^1.1.9",
     "vue": "^2.6.11",
     "vue-axios": "^2.1.5",
+    "vue-chartjs": "^3.5.1",
     "vue-router": "^3.1.6",
     "vuex": "^3.2.0",
     "xss-filters": "^1.2.7"

--- a/src/components/LineChart.vue
+++ b/src/components/LineChart.vue
@@ -1,0 +1,14 @@
+<script>
+import { Bar, mixins } from 'vue-chartjs'
+const { reactiveProp } = mixins
+
+export default {
+  extends: Bar,
+  mixins: [reactiveProp],
+  props: ['chartData', 'options'],
+  mounted () {
+    // Overwriting base render method with actual data.
+    this.renderChart(this.chartData, this.options)
+  }
+}
+</script>

--- a/src/components/LineChart.vue
+++ b/src/components/LineChart.vue
@@ -9,6 +9,12 @@ export default {
   mounted () {
     // Overwriting base render method with actual data.
     this.renderChart(this.chartData, this.options)
+  },
+  watch: {
+    options: function () {
+      this.$data._chart.options = this.options
+      this.$data._chart.update()
+    }
   }
 }
 </script>

--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -41,6 +41,9 @@
           <li class="nav-item" v-if='modules.user_tasks'>
           <router-link class="nav-link" :to='{"name": "page.user_tasks", params: { group: group, cluster: cluster } }'>Cruise Control Tasks</router-link>
           </li>
+          <li class="nav-item" v-if='modules.user_tasks'>
+          <router-link class="nav-link" :to='{"name": "page.resource_distributions", params: { group: group, cluster: cluster } }'>Resource distributions</router-link>
+          </li>
           <!--
           <li class="nav-item" v-if='modules.admin_state'>
             <router-link :to='{"name": "page.admin_state", params: { group: group, cluster: cluster, embed: true } }'>&#9881; Sampling Admin</router-link>

--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -41,7 +41,7 @@
           <li class="nav-item" v-if='modules.user_tasks'>
           <router-link class="nav-link" :to='{"name": "page.user_tasks", params: { group: group, cluster: cluster } }'>Cruise Control Tasks</router-link>
           </li>
-          <li class="nav-item" v-if='charts.enabled'>
+          <li class="nav-item" v-if='modules.chart_page'>
           <router-link class="nav-link" :to='{"name": "page.resource_distributions", params: { group: group, cluster: cluster } }'>Resource distributions</router-link>
           </li>
           <!--
@@ -76,8 +76,7 @@ export default {
   },
   data () {
     return {
-      modules: this.$store.state.modules,
-      charts: this.$store.state.charts
+      modules: this.$store.state.modules
     }
   },
   computed: {

--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -41,7 +41,7 @@
           <li class="nav-item" v-if='modules.user_tasks'>
           <router-link class="nav-link" :to='{"name": "page.user_tasks", params: { group: group, cluster: cluster } }'>Cruise Control Tasks</router-link>
           </li>
-          <li class="nav-item" v-if='modules.user_tasks'>
+          <li class="nav-item" v-if='charts.enabled'>
           <router-link class="nav-link" :to='{"name": "page.resource_distributions", params: { group: group, cluster: cluster } }'>Resource distributions</router-link>
           </li>
           <!--
@@ -76,7 +76,8 @@ export default {
   },
   data () {
     return {
-      modules: this.$store.state.modules
+      modules: this.$store.state.modules,
+      charts: this.$store.state.charts
     }
   },
   computed: {

--- a/src/components/ResourceDistribution.vue
+++ b/src/components/ResourceDistribution.vue
@@ -1,8 +1,11 @@
 <template>
   <div>
     <h1 class="text-center">
-      {{ resource }} distribution across brokers per topic in cluster {{ cluster }} ({{ group }})
+      Cluster {{ cluster }} ({{ group }})
     </h1>
+    <h2 class="text-center">
+      {{ resource }} distribution across brokers per topic
+    </h2>
 
     <div class="col-5 mx-auto">
       <div class="row">
@@ -150,7 +153,12 @@ class Topic {
     if (this.disk === 0) return '0 MiB'
     const k = 1024
     const sizes = ['MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
-    const i = Math.floor(Math.log(this.disk) / Math.log(k))
+    let i
+    if (this.disk <= 1) {
+      i = 0
+    } else {
+      i = Math.floor(Math.log(this.disk) / Math.log(k))
+    }
     return parseFloat((this.disk / Math.pow(k, i)).toFixed(decimals)) + ' ' + sizes[i]
   }
 }
@@ -223,7 +231,12 @@ export default {
           this.brokerList = [...brokerList].sort()
         })
         .then(e => {
-          this.cachedKccData = new Map([...this.cachedKccData.entries()].sort().reverse())
+          this.cachedKccData = new Map([...this.cachedKccData.entries()].sort((a, b) => {
+            if (a[1].disk > b[1].disk) {
+              return -1
+            }
+            return 1
+          }))
         })
         .catch(error => {
           this.error = error

--- a/src/components/ResourceDistribution.vue
+++ b/src/components/ResourceDistribution.vue
@@ -1,0 +1,267 @@
+<template>
+  <div>
+    <h1 class="text-center">
+      Current leadership distribution across brokers per topic
+    </h1>
+
+    <div class="col-5 mx-auto">
+      <div class="row">
+        <div class="col-8 mx-auto">
+          <input
+            type="text"
+            class="form-control"
+            v-model="filter"
+            placeholder="filter topics.."
+            :disabled="stacked"
+          />
+        </div>
+        <div class="col-4 mx-auto">
+          <div class="form-check">
+            <input
+              v-model="stacked"
+              type="checkbox"
+              class="form-check-input"
+              id="stackedCheckBox"
+            />
+            <label class="form-check-label" for="stackedCheckBox">
+              Stacked view
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="alert alert-danger" role="alert" v-if="error">
+      {{ error }}
+    </div>
+
+    <div class="row" v-bind:class="{ active: loaded }" v-show="stacked">
+      <div class="col-8 mx-auto">
+        <div class="card mx-4 mt-4">
+          <div class="card-inner">
+            <LineChart
+              :chart-data="formatStackedData"
+              :options="getStackedOptions"
+            ></LineChart>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      class="row mx-auto"
+      v-bind:class="{ active: loaded }"
+      v-show="!stacked"
+    >
+      <div
+        class="col-4"
+        v-for="item in cachedKccData"
+        v-bind:key="item[0]"
+        v-show="item[0].toLowerCase().includes(filter.toLowerCase())"
+      >
+        <div class="card mt-4">
+          <div class="card-inner">
+            <LineChart
+              :chart-data="formatItemData(item, 'leaders')"
+              :options="formatItemOptions(item)"
+            ></LineChart>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+
+<script>
+import LineChart from '@/components/LineChart.vue'
+const backgroundColors = ['#ffffd9', '#edf8b1', '#c7e9b4', '#7fcdbb', '#41b6c4', '#1d91c0', '#225ea8', '#253494', '#081d58']
+
+class Topic {
+  constructor () {
+    this.leaders = {}
+    this.replicas = {}
+    this.replicationFactor = 0
+  }
+
+  addLeader (item) {
+    let broker = item.leader
+    if (this.leaders[broker] === undefined) {
+      this.leaders[broker] = 1
+      return
+    }
+    this.leaders[broker]++
+  }
+
+  addReplicas (item) {
+    let replicas = Object.values(item.followers)
+    replicas.push(item.leader)
+
+    replicas.map(follower => {
+      if (this.replicas[follower] === undefined) {
+        this.replicas[follower] = 1
+        return
+      }
+
+      this.replicas[follower]++
+    })
+  }
+}
+
+export default {
+  name: 'ResourceDistribution',
+  components: {
+    LineChart
+  },
+  props: {
+    group: String,
+    cluster: String
+  },
+  data () {
+    return {
+      stacked: false,
+      filter: '',
+      loaded: 0,
+      cachedKccData: null,
+      error: null,
+      brokerList: []
+    }
+  },
+
+  beforeMount () {
+    this.argsChanged()
+  },
+  watch: {
+    group: function (ogroup, ngroup) {
+      this.argsChanged()
+    },
+    cluster: function (ocluster, ncluster) {
+      this.argsChanged()
+    }
+  },
+
+  mounted () {
+    this.fetchKccData()
+  },
+
+  methods: {
+    argsChanged () {
+      const newurl = this.$store.getters.getnewurl(this.group, this.cluster)
+      this.$store.commit('seturl', newurl)
+    },
+
+    cacheKccDataItem (item) {
+      if (!this.cachedKccData.has(item.topic)) {
+        this.cachedKccData.set(item.topic, new Topic())
+      }
+      this.cachedKccData.get(item.topic).addLeader(item)
+      this.cachedKccData.get(item.topic).addReplicas(item)
+      this.cachedKccData.get(item.topic).replicationFactor = Math.max(this.cachedKccData.get(item.topic).replicationFactor, item.followers.length + 1)
+    },
+
+    fetchKccData () {
+      this.cachedKccData = new Map()
+      this.$http
+        .get(this.$helpers.getURL('partitionload', {}))
+        .then(response => {
+          this.rawresponse = response
+          let brokerList = new Set()
+          for (let record of response.data.records) {
+            this.cacheKccDataItem(record)
+            brokerList.add(record.leader, ...record.followers)
+          }
+          this.brokerList = [...brokerList].sort()
+        })
+        .then(e => {
+          this.loaded++
+        })
+        .catch(error => {
+          this.error = error
+        })
+    },
+
+    formatItemData (item, resource) {
+      let leaders = item[1].leaders
+      return {
+        datasets: [{
+          data: [...Object.values(leaders)],
+          backgroundColor: 'rgba(7, 66, 160, 0.5)'
+        }],
+        labels: [...Object.keys(leaders)].map(e => 'broker ' + e)
+      }
+    },
+
+    formatItemOptions (item) {
+      let title = `${item[0]} (RF ${item[1].replicationFactor})`
+      return this.getOptions(title)
+    },
+
+    getOptions (title) {
+      let options = {
+        legend: {
+          display: false
+        },
+        scales: {
+          yAxes: [{
+            ticks: {
+              beginAtZero: true,
+              stepSize: 1
+            },
+            scaleLabel: {
+              labelString: 'nb leaders',
+              display: true
+            }
+          }]
+        },
+        title: {
+          display: true,
+          text: title
+        }
+      }
+      return options
+    }
+
+  },
+  computed: {
+    formatStackedData (resource) {
+      let stackedKccData = {
+        labels: this.brokerList,
+        datasets: []
+      }
+
+      if (this.cachedKccData === null) {
+        return stackedKccData
+      }
+
+      let counter = 0
+      for (let topic of this.cachedKccData) {
+        let dataset = {
+          label: topic[0],
+          data: [],
+          backgroundColor: backgroundColors[counter]
+        }
+        counter++
+        counter = counter % backgroundColors.length
+        for (let broker of this.brokerList) {
+          let value = (topic[1].leaders[broker] !== undefined) ? topic[1].leaders[broker] : 0
+          dataset.data.push(value)
+        }
+        stackedKccData.datasets.push(dataset)
+      }
+
+      return stackedKccData
+    },
+
+    getStackedOptions () {
+      let options = this.getOptions('stacked leaders')
+      options.scales.xAxes = [{ stacked: true }]
+      options.scales.yAxes[0].stacked = true
+      options.legend = {
+        display: true,
+        position: 'bottom'
+      }
+      return options
+    }
+  }
+}
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,7 @@ import AdminBroker from '@/components/AdminBroker'
 import AdminSampling from '@/components/AdminSampling'
 import UserTasks from '@/components/UserTasks'
 import ConfigInsights from '@/components/ConfigInsights'
+import ResourceDistribution from '@/components/ResourceDistribution'
 import PeerReview from '@/components/PeerReview'
 import store from '@/store'
 import Summary from '@/components/Summary'
@@ -128,6 +129,12 @@ export default new Router({
           name: 'page.admin_state',
           path: 'admin_state',
           component: AdminSampling,
+          props: true
+        },
+        {
+          name: 'page.resource_distributions',
+          path: 'resource_distributions',
+          component: ResourceDistribution,
           props: true
         },
         {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -15,6 +15,9 @@ export default new Vuex.Store({
     online: true,
     autoReloadEnabled: false, // disabled by default
     autoReloadInterval: 30000, // 30 seconds
+    charts: {
+      enabled: true
+    },
     // these control the enablement of a module in cruise control
     modules: {
       state: true,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,6 +7,7 @@ Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {
+    chartColors: ['#ffffd9', '#edf8b1', '#c7e9b4', '#7fcdbb', '#41b6c4', '#1d91c0', '#225ea8', '#253494', '#081d58'],
     configurl: './static/config.csv', // path to the cruise-control REST end-points
     config: {}, // remote cc urls information
     configError: null, // true if we have problem loading configuration
@@ -15,11 +16,9 @@ export default new Vuex.Store({
     online: true,
     autoReloadEnabled: false, // disabled by default
     autoReloadInterval: 30000, // 30 seconds
-    charts: {
-      enabled: true
-    },
     // these control the enablement of a module in cruise control
     modules: {
+      chart_page: true,
       state: true,
       kafkaclusterstate: true,
       load: true,


### PR DESCRIPTION
Following https://github.com/linkedin/cruise-control-ui/issues/54
- 1st commit adds the leaders distribution charts, which could then be generalized for other resources
- 2nd commit adds the replicas distribution charts
- 3rd commit adds the CPU repartition charts
- 4th commit divers fixes