### PR TITLE
Round by 2 decimal place instead of integer

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,7 @@ Vue.filter('formatUnits', function (v) {
   for (var i = 0; i < units.length; i++) {
     if (v <= Math.pow(1024, i + 1)) {
       var value = v / Math.pow(1024, i)
-      value = value.toFixed(0)
+      value = value.toFixed(2)
       return value + ' ' + units[i]
     }
   }


### PR DESCRIPTION
The original rounding on DiskMB (as integer) is misleading. 

For example, in the executor, some rebalance task has a total of 6.459 TB of data to be moved:
- If 3.846 TB of data is finished moving, then 2.613 TB of data are waiting to be moved
- By current rounding (`toFixed(0)`), it will be displayed as  

| Total Data To Move | Finished Data Movement | Remaining Data |
|:-------------:|:-------------:|:-----:|
| 6 TB   | 4 TB | 3 TB |

- Above obviously doesn't add up, if we try to keep 2 decimal places it will be more accurate without losing aesthetic

| Total Data To Move | Finished Data Movement | Remaining Data |
|:-------------:|:-------------:|:-----:|
| 6.46 TB   | 3.85 TB | 2.61 TB |

Benefits to keep 2 decimal places:
1. Relatively more accurate, since units like MB/GB/TB are good for most Kafka nodes 
2. User can tell the progress of executor easier (imagine how long it will take to move 1 TB of data, during this entire time, the integer part is not gonna move) 
3. May take some space from UI but not too bad

If 2 decimal places are not good enough for PB or higher units, a hover-over title showing a formatted original MB number should be good enough.