### PR TITLE
display full error message in resources distribution

### DIFF
--- a/src/components/ResourceDistribution.vue
+++ b/src/components/ResourceDistribution.vue
@@ -239,7 +239,7 @@ export default {
           }))
         })
         .catch(error => {
-          this.error = error
+          this.error = error.response.data
         })
     },
     formatItemData (item) {


### PR DESCRIPTION
instead of just printing a simple error code, display the full stack trace as bellow
before:
![image](https://user-images.githubusercontent.com/10009508/105710251-1e2bb700-5f17-11eb-9239-abe7af854226.png)

after: 
![image](https://user-images.githubusercontent.com/10009508/105710199-0fdd9b00-5f17-11eb-9ac9-80cfa0bc62e8.png)
