### PR TITLE
Add missing slash in url generation in summary overview

### DIFF
--- a/src/components/Summary.vue
+++ b/src/components/Summary.vue
@@ -51,8 +51,7 @@ export default {
   },
   methods: {
     stats_url (endpoint) {
-      let params = {'json': 'true'}
-      return this.$helpers.getURL('kafka_cluster_state', params)
+      return endpoint + '/kafka_cluster_state?json=true'
     }
   },
   data () {

--- a/src/components/Summary.vue
+++ b/src/components/Summary.vue
@@ -51,7 +51,8 @@ export default {
   },
   methods: {
     stats_url (endpoint) {
-      return endpoint + '/kafka_cluster_state?json=true'
+      let params = {'json': 'true'}
+      return this.$helpers.getURL('kafka_cluster_state', params)
     }
   },
   data () {

--- a/src/components/SummaryRow.vue
+++ b/src/components/SummaryRow.vue
@@ -81,7 +81,7 @@ export default {
     getKafkaState () {
       const vm = this
       vm.loading = true
-      let url = this.url + 'kafka_cluster_state'
+      let url = this.url + (this.url.endsWith('/') ? 'kafka_cluster_state' : '/kafka_cluster_state')
       vm.req = vm.$http.get(url, {params: {json: true}, withCredentials: true}).then((r) => {
         if (r.data === null || r.data === undefined || r.data === '') {
           vm.error = true

--- a/src/components/SummaryRow.vue
+++ b/src/components/SummaryRow.vue
@@ -81,7 +81,7 @@ export default {
     getKafkaState () {
       const vm = this
       vm.loading = true
-      let url = vm.$helpers.getURL('kafka_cluster_state')
+      let url = this.url + (this.url.endsWith('/') ? 'kafka_cluster_state' : '/kafka_cluster_state')
       vm.req = vm.$http.get(url, {params: {json: true}, withCredentials: true}).then((r) => {
         if (r.data === null || r.data === undefined || r.data === '') {
           vm.error = true

--- a/src/components/SummaryRow.vue
+++ b/src/components/SummaryRow.vue
@@ -81,7 +81,7 @@ export default {
     getKafkaState () {
       const vm = this
       vm.loading = true
-      let url = this.url + (this.url.endsWith('/') ? 'kafka_cluster_state' : '/kafka_cluster_state')
+      let url = vm.$helpers.getURL('kafka_cluster_state')
       vm.req = vm.$http.get(url, {params: {json: true}, withCredentials: true}).then((r) => {
         if (r.data === null || r.data === undefined || r.data === '') {
           vm.error = true


### PR DESCRIPTION
This PR adds a missing slash to the url generated by the Summary overview to fetch the kafka_cluster_state. 

According to the Wiki the format for config.csv is like this:

```
region-1,cc-one,/cc-1/kafkacruisecontrol
region-1,cc-two,/cc-2/kafkacruisecontrol
region-1,cc-three,/cc-3/kafkacruisecontrol
```

However, with this the URL generated by the Summary overview is missing a slash. The GET requests for the kafka_cluster_state are hitting `https://mydomain.com/cruisecontrol/clustername/kafkacruisecontrolkafka_cluster_state?json=true` which is wrong. 

This PR adds the slash if it is missing.