### PR TITLE
Format with good units DataToMoveMB in proposal view

### DIFF
--- a/src/components/Proposals.vue
+++ b/src/components/Proposals.vue
@@ -31,7 +31,7 @@
             <th>Number of Replica Movements</th>
             <th>Number of Leader Movements</th>
             <th>Recent Windows</th>
-            <th>Data to Move (MB)</th>
+            <th>Data to Move</th>
             <th>Monitored Partitions Coverage</th>
           </tr>
         </thead>
@@ -40,7 +40,7 @@
             <td>{{ numReplicaMovements }}</td>
             <td>{{ numLeaderMovements }}</td>
             <td>{{ recentWindows }}</td>
-            <td>{{ dataToMoveMB }}</td>
+            <td>{{ dataToMoveMB | formatUnits }}</td>
             <td>{{ monitoredPartitionsPercentage ? monitoredPartitionsPercentage.toFixed(2) : null }}%</td>
           </tr>
         </tbody>


### PR DESCRIPTION
Before in proposal view : 
Data to move field : only in MB without space (hard to read / error prone)

<img width="1636" alt="Screenshot 2024-03-04 at 14 10 48" src="https://github.com/linkedin/cruise-control-ui/assets/7195546/9871b4c4-bc4d-4c58-9703-da91bc391a45">

After : 
Display with adapted unit (MB / GB / TB...)
<img width="1636" alt="Screenshot 2024-03-04 at 14 11 25" src="https://github.com/linkedin/cruise-control-ui/assets/7195546/206e461a-b18d-41a7-91aa-df99c7ee43c5">

