### PR TITLE
add replication throttle config to rebalance/add/remove/demote options

### DIFF
--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -63,7 +63,7 @@ app.use(hotMiddleware)
 
 // serve pure static assets
 var staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)
-app.use(staticPath, express.static('./static'))
+app.use(`/${staticPath}`, express.static(path.join(__dirname, '../static')))
 
 var uri = 'http://0.0.0.0:' + port
 

--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -1,5 +1,6 @@
 /* Copyright 2017-2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information. */
 
+var path = require('path')
 var utils = require('./utils')
 var webpack = require('webpack')
 var config = require('../config')

--- a/src/components/AdminBroker.vue
+++ b/src/components/AdminBroker.vue
@@ -247,6 +247,12 @@
                   <input class="form-control" type='number' min=0 v-model='concurrent_leader_movements' placeholder='(CC Default)'>
                 </div>
               </div>
+              <div class="form-row">
+                <label class="col-sm-6">Replication Throttle (bytes per second):</label>
+                <div class="col-sm-6">
+                  <input class="form-control" type='number' min=0 v-model='replication_throttle' placeholder='(CC Default)'>
+                </div>
+              </div>
             </div>
           </div>
           </template>
@@ -607,6 +613,7 @@ export default {
       excluded_topics: '', // Check CC Documentation
       concurrent_partition_movements_per_broker: null, // Check CC Documentation
       concurrent_leader_movements: null, // Check CC Documentation
+      replication_throttle: null, // Check CC Documentation
       throttle_removed_broker: false, // Check CC Documentation
       throttle_added_broker: false, // Check CC Documentation
       // workflow
@@ -748,6 +755,10 @@ export default {
         //  &concurrent_partition_movements_per_broker=[concurrency]
         //  &concurrent_leader_movements=[concurrency]
         //  &excluded_topics=[TOPICS]
+        //  &replication_throttle=[throttle]
+        if (vm.replication_throttle) {
+          params.replication_throttle = vm.replication_throttle
+        }
         return vm.$helpers.getURL('rebalance', params)
       }
       if (vm.actionName === 'rebalance_disk') {

--- a/src/components/AdminBroker.vue
+++ b/src/components/AdminBroker.vue
@@ -267,31 +267,38 @@
       <div class="alert alert-warning" v-if='selectedBrokers.length > 0 && actionName === "demote"'>
         <h5>Demote Broker Flags</h5>
         <hr>
-        <div class="row">
-          <div class="col-md-4">
-            <div class="form-inline">
-              <label class="form-label"> Concurrent Leader Movements </label>
-              <input type="number" class="form-input" v-model='concurrent_leader_movements' placeholder='(CC Default)'>
+        <form>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" v-model='dryrun'>
+            <label class="form-check-label">DryRun</label>
+          </div>
+          <hr>
+          <div class="row">
+            <div class="col-md-4">
+              <div class="form-inline">
+                <label class="form-label"> Concurrent Leader Movements </label>
+                <input type="number" class="form-input" v-model='concurrent_leader_movements' placeholder='(CC Default)'>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="form-inline">
+                <label class="form-label">Replication Throttle (bytes per second):</label>
+                <input class="form-input" type='number' min=0 v-model='replication_throttle' placeholder='(CC Default)'>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" v-model='disallow_capacity_estimation'>
+                <label class="form-check-label">
+                  Disallow Capacity Estimation
+                </label>
+              </div>
             </div>
           </div>
-          <div class="col-md-3">
-            <div class="form-check form-check-inline">
-              <input class="form-check-input" type="checkbox" v-model='disallow_capacity_estimation'>
-              <label class="form-check-label">
-                Disallow Capacity Estimation
-              </label>
-            </div>
-          </div>
-          <div class="col-md-3">
-            <div class="form-check form-check-inline">
-              <input class="form-check-input" type="checkbox" v-model='dryrun'>
-              <label class="form-check-label">DryRun</label>
-            </div>
-          </div>
-          <div class="col-md-2">
+          <div class="text-right">
             <button @click='actionBroker' class="btn btn-primary">Demote Brokers {{ selectedBrokers }}</button>
           </div>
-        </div>
+        </form>
       </div>
 
       <!-- Remove Broker Flags -->
@@ -404,6 +411,12 @@
                 <label class="col-sm-6">Concurrent Leader Movements:</label>
                 <div class="col-sm-6">
                   <input class="form-control" type='number' min=0 v-model='concurrent_leader_movements' placeholder='(CC Default)'>
+                </div>
+              </div>
+              <div class="form-row">
+                <label class="col-sm-6">Replication Throttle (bytes per second):</label>
+                <div class="col-sm-6">
+                  <input class="form-control" type='number' min=0 v-model='replication_throttle' placeholder='(CC Default)'>
                 </div>
               </div>
             </div>
@@ -525,6 +538,12 @@
                 <label class="col-sm-6">Concurrent Leader Movements:</label>
                 <div class="col-sm-6">
                   <input class="form-control" type='number' min=0 v-model='concurrent_leader_movements' placeholder='(CC Default)'>
+                </div>
+              </div>
+              <div class="form-row">
+                <label class="col-sm-6">Replication Throttle (bytes per second):</label>
+                <div class="col-sm-6">
+                  <input class="form-control" type='number' min=0 v-model='replication_throttle' placeholder='(CC Default)'>
                 </div>
               </div>
             </div>
@@ -651,6 +670,12 @@ export default {
         if (vm.disallow_capacity_estimation) {
           params.allow_capacity_estimation = !vm.disallow_capacity_estimation
         }
+        if (vm.concurrent_leader_movements) {
+          params.concurrent_leader_movements = vm.concurrent_leader_movements
+        }
+        if (vm.replication_throttle) {
+          params.replication_throttle = vm.replication_throttle
+        }
       }
       if (vm.actionName === 'remove' || vm.actionName === 'add' || vm.actionName === 'rebalance') {
         if (vm.goals1.length > 0) {
@@ -680,6 +705,9 @@ export default {
         if (vm.concurrent_leader_movements) {
           params.concurrent_leader_movements = vm.concurrent_leader_movements
         }
+        if (vm.replication_throttle) {
+          params.replication_throttle = vm.replication_throttle
+        }
         if (vm.excluded_topics && vm.excluded_topics.length > 0) {
           // Disable this due to https://github.com/linkedin/cruise-control-ui/issues/40
           // params.excluded_topics = xssFilters.uriQueryInDoubleQuotedAttr(vm.excluded_topics)
@@ -700,6 +728,7 @@ export default {
         //  &concurrent_partition_movements_per_broker=[concurrency]
         //  &concurrent_leader_movements=[concurrency]
         //  &throttle_removed_broker=[true/false]
+        //  &replication_throttle=[throttle]
         //  &json=[true/false]
         if (vm.throttle_removed_broker) {
           params.throttle_removed_broker = params.throttle_removed_broker
@@ -713,6 +742,7 @@ export default {
         //  &json=[true/false]
         //  &allow_capacity_estimation=[true/false]
         //  &concurrent_leader_movements=[concurrency]
+        //  &replication_throttle=[throttle]
         return vm.$helpers.getURL('demote_broker', params)
       }
       if (vm.actionName === 'add') {
@@ -730,6 +760,7 @@ export default {
         //  &skip_hard_goal_check=[true/false]
         //  &excluded_topics=[TOPICS]
         //  &use_ready_default_goals=[true/false]
+        //  &replication_throttle=[throttle]
         if (vm.throttle_added_broker) {
           params.throttle_added_broker = vm.throttle_added_broker
         }
@@ -756,9 +787,6 @@ export default {
         //  &concurrent_leader_movements=[concurrency]
         //  &excluded_topics=[TOPICS]
         //  &replication_throttle=[throttle]
-        if (vm.replication_throttle) {
-          params.replication_throttle = vm.replication_throttle
-        }
         return vm.$helpers.getURL('rebalance', params)
       }
       if (vm.actionName === 'rebalance_disk') {


### PR DESCRIPTION
adds replication throttle configuration to configuration options for rebalance, add, remove, and demote broker
- https://github.com/linkedin/cruise-control/wiki/REST-APIs#trigger-a-workload-balance
- https://github.com/linkedin/cruise-control/wiki/REST-APIs#add-a-list-of-new-brokers-to-kafka-cluster
- https://github.com/linkedin/cruise-control/wiki/REST-APIs#decommission-a-list-of-brokers-from-the-kafka-cluster
- https://github.com/linkedin/cruise-control/wiki/REST-APIs#demote-a-list-of-brokers-from-the-kafka-cluster

plus move around ui for demote to fit the new input box better
fix bug with demote broker where `concurrent_leader_movements` wasn't being set

cc https://github.com/linkedin/cruise-control-ui/issues/126

<img width="1202" alt="Screenshot 2025-01-21 at 11 44 15" src="https://github.com/user-attachments/assets/b7391ea2-cd52-4215-a5bd-af59964ef8ca" />

<img width="1155" alt="Screenshot 2025-01-22 at 13 45 41" src="https://github.com/user-attachments/assets/dca49e34-0b5e-4628-8423-4476a53cdb8e" />


----

other fixes
- dev server wouldn't start without adding require path (node version v18.16.1)
```
❯ npm run dev

> cruise-control-ui@0.3.0 dev
> test -d cruise-control-ui && cd cruise-control-ui; node build/dev-server.js

/Users/countableset/code/countableset/cruise-control-ui/build/webpack.dev.conf.js:33
      favicon: path.resolve(__dirname, '../src/assets/images/cc-favicon.png'),
               ^

ReferenceError: path is not defined
    at Object.<anonymous> (/Users/countableset/code/countableset/cruise-control-ui/build/webpack.dev.conf.js:33:16)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/Users/countableset/code/countableset/cruise-control-ui/build/dev-server.js:15:21)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47

Node.js v18.16.1
```
- `localhost:8090/static/config.csv` would 404 in dev server, changed express config to `app.use(`/${staticPath}`, express.static(path.join(__dirname, '../static')))`